### PR TITLE
Fixed ISC input for two-sample permutation test

### DIFF
--- a/tutorials/10-isc.ipynb
+++ b/tutorials/10-isc.ipynb
@@ -543,14 +543,11 @@
    },
    "outputs": [],
    "source": [
-    "# Concatenate the data \n",
-    "bold_all_tasks = np.dstack([bold[task_name] for task_name in all_task_names])\n",
-    "\n",
-    "# Re-compute ISC for all tasks (this will take a while...) \n",
-    "isc_maps_all_tasks = isc(bold_all_tasks, pairwise=False, summary_statistic=None)\n",
+    "# Concatenate ISCs from both tasks\n",
+    "isc_maps_all_tasks = np.vstack([isc_maps[task_name] for\n",
+    "                                task_name in all_task_names])\n",
     "\n",
     "print('group_assignment: {}'.format(group_assignment))\n",
-    "print('bold_all_tasks: {}' .format(np.shape(bold_all_tasks)))\n",
     "print('isc_maps_all_tasks: {}' .format(np.shape(isc_maps_all_tasks)))"
    ]
   },


### PR DESCRIPTION
We should not recompute leave-one-out ISCs on stacked data from two tasks—because the mean of _N_ – 1 subjects will be computed across both tasks. Instead, we compute leave-one-out ISCs separately per task, stack them, and pass this directly to `permutation_isc`.