### PR TITLE
Fixed minor issues for plots/comments in 03-classification

### DIFF
--- a/tutorials/03-classification.ipynb
+++ b/tutorials/03-classification.ipynb
@@ -1283,7 +1283,7 @@
     "M. Kumar added section introductions.  \n",
     "K.A. Norman provided suggestions on the overall content and made edits to this notebook.  \n",
     "C. Ellis implemented feedback from cmhn-s19. \n",
-    "S. Rhoads added few enhancements for clarity"
+    "S. Rhoads edited plots and comments to improve clarity."
    ]
   },
   {

--- a/tutorials/03-classification.ipynb
+++ b/tutorials/03-classification.ipynb
@@ -1282,7 +1282,7 @@
     "Q. Lu a lot of edits...   \n",
     "M. Kumar added section introductions.  \n",
     "K.A. Norman provided suggestions on the overall content and made edits to this notebook.  \n",
-    "C. Ellis implemented feedback from cmhn-s19. \n",
+    "C. Ellis implemented feedback from cmhn-s19.  \n",
     "S. Rhoads edited plots and comments to improve clarity."
    ]
   },

--- a/tutorials/03-classification.ipynb
+++ b/tutorials/03-classification.ipynb
@@ -1282,7 +1282,8 @@
     "Q. Lu a lot of edits...   \n",
     "M. Kumar added section introductions.  \n",
     "K.A. Norman provided suggestions on the overall content and made edits to this notebook.  \n",
-    "C. Ellis implemented feedback from cmhn-s19"
+    "C. Ellis implemented feedback from cmhn-s19. \n",
+    "S. Rhoads added few enhancements for clarity"
    ]
   },
   {

--- a/tutorials/03-classification.ipynb
+++ b/tutorials/03-classification.ipynb
@@ -365,14 +365,14 @@
    "outputs": [],
    "source": [
     "# Create a sequence of timepoints that a TR occurred on\n",
-    "tr_time = np.arange(0, (vdc_TRs_run - 1) * 1.5 + 1, 1.5)\n",
+    "time_points = np.arange(0, (vdc_TRs_run - 1) * 1.5 + 1, 1.5)\n",
     "\n",
     "# Plot the data\n",
     "f, ax = plt.subplots(1,1, figsize = (12,5))\n",
-    "ax.plot(tr_time, stim_label_TR[0:vdc_TRs_run, 0], c='orange')\n",
+    "ax.plot(time_points, stim_label_TR[0:vdc_TRs_run, 0], c='orange')\n",
     "\n",
     "ax.set_ylabel('Stimuli labels')\n",
-    "ax.set_xlabel('TR')"
+    "ax.set_xlabel('Time in secs')"
    ]
   },
   {
@@ -480,9 +480,15 @@
    "outputs": [],
    "source": [
     "# Plot the design\n",
-    "plt.plot(stim_A)\n",
-    "plt.title('Stimulus Timing: Block 10 s (5 TRs)')\n",
-    "plt.xlabel('TRs')"
+    "fig, (ax0, ax1) = plt.subplots(nrows=2, constrained_layout=True)\n",
+    "\n",
+    "ax0.plot(stim_A.repeat(trDuration))\n",
+    "ax0.set_xlabel('Time in secs')\n",
+    "\n",
+    "ax1.plot(stim_A)\n",
+    "ax1.set_xlabel('TRs')\n",
+    "\n",
+    "fig.suptitle('Stimulus Timing: Block 10 s (5 TRs)')"
    ]
   },
   {
@@ -638,7 +644,7 @@
     "ax.set_yticklabels(vdc_label_dict.values())\n",
     "\n",
     "ax.set_title('Stimulus Presentation for Run 1')\n",
-    "ax.set_xlabel('Time (seconds)')\n"
+    "ax.set_xlabel('Time in secs')\n"
    ]
   },
   {
@@ -692,8 +698,11 @@
     "ax.plot(tr_time, stim_label_TR[0:vdc_TRs_run, 0], c='blue',alpha=0.2)\n",
     "ax.plot(tr_time, stim_label_TR_shifted[0:310], c='orange')\n",
     "\n",
+    "ax.set_yticks(list(vdc_label_dict.keys()))\n",
+    "ax.set_yticklabels(vdc_label_dict.values())\n",
+    "\n",
     "ax.set_ylabel('Stimuli labels')\n",
-    "ax.set_xlabel('TR')\n",
+    "ax.set_xlabel('Time in secs')\n",
     "\n",
     "plt.legend(['Original', 'Shifted'])"
    ]
@@ -848,7 +857,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -1005,7 +1013,7 @@
     "# Fit a svm\n",
     "model.fit(X_train, labels)\n",
     "\n",
-    "# Calculate the accuracy for the hold out run\n",
+    "# Calculate the accuracy for training set\n",
     "score = model.score(X_train, labels)\n",
     "print('Accuracy = %s' % score)"
    ]


### PR DESCRIPTION
Fixes #52
- Section 1.2: Relabeled x-axis for stimulus timing figure as "time in secs"
- Section 1.3.1: Added subplots to make the distinction between "time in secs" and TRs more clear
- Section 1.3.2: Relabeled x-axis for the time-shift figure as "time in secs" and added stimulus labels on the y-axis 
- Section 2.3.1: Edited comment in "double-dipping" cell